### PR TITLE
Fix: Improve Dockerfile build process for SvelteKit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,23 @@ WORKDIR /app
 # Copy package.json and package-lock.json (or npm-shrinkwrap.json)
 COPY package*.json ./
 
-# Install production dependencies
-RUN npm install --omit=dev
+# Install ALL dependencies (including devDependencies for the build)
+RUN npm install
 
 # Copy the rest of the application code
 COPY . .
 
+# Prepare SvelteKit (generates .svelte-kit/tsconfig.json etc.)
+RUN npm run prepare
+
 # Build the SvelteKit application
 RUN npm run build
+
+# Remove development dependencies
+RUN npm prune --production
 
 # Expose the port the app runs on
 EXPOSE 8080
 
 # Define the command to run the application
-# The PORT environment variable will be set by Cloud Run.
-# SvelteKit with adapter-node by default listens to process.env.PORT or 3000.
-# The 'start' script in package.json is 'node build'.
-# The build output of adapter-node is a standalone Node server.
 CMD ["npm", "start"]


### PR DESCRIPTION
This commit addresses issues in the Dockerfile to ensure a more robust and cleaner build process for the SvelteKit application.

Changes include:
- Ensured all dependencies (including devDependencies) are installed before the build using `RUN npm install`.
- Added `RUN npm run prepare` before `RUN npm run build` to generate necessary SvelteKit files (e.g., `.svelte-kit/tsconfig.json`) and resolve related build warnings.
- Removed development dependencies after the build using `RUN npm prune --production` to keep the final image lean.

These changes resolve the "vite: not found" error and warnings related to missing `tsconfig.json` during the Docker build.